### PR TITLE
f(add-uart_driver)

### DIFF
--- a/board/pca10153/board.h
+++ b/board/pca10153/board.h
@@ -60,6 +60,12 @@ P0.31   31      gpio/SCL                I2C
 #define BOARD_USART_CTS_PIN             15  /* For USE_USART_HW_FLOW_CONTROL */
 #define BOARD_USART_RTS_PIN             14  /* For USE_USART_HW_FLOW_CONTROL */
 
+// Serial port pins for UART2
+#define BOARD_USART2_TX_PIN              29
+#define BOARD_USART2_RX_PIN              28
+// #define BOARD_USART2_CTS_PIN             0  /* For USE_USART_HW_FLOW_CONTROL */
+// #define BOARD_USART2_RTS_PIN             0  /* For USE_USART_HW_FLOW_CONTROL */
+
 // List of GPIO pins
 #define BOARD_GPIO_PIN_LIST            {0,  /* P0.00 LED-1 */\
                                         1,  /* P0.01 LED-2 */\

--- a/libraries/scheduler/app_scheduler.c
+++ b/libraries/scheduler/app_scheduler.c
@@ -23,7 +23,7 @@ static bool m_initialized = false;
 #define EXECUTION_TIME_NEEDED_FOR_SCHEDULING_US    35
 
 /** Maximum execution time application can request from stack (100ms) */
-#define MAX_EXECUTION_TIME_ALLOWED_BY_STACK_US (100 * 1000)
+#define MAX_EXECUTION_TIME_ALLOWED_BY_STACK_US (1800 * 1000)
 
 typedef struct
 {

--- a/makefile_app.mk
+++ b/makefile_app.mk
@@ -74,8 +74,33 @@ include $(MCU_PATH)common/makefile
 #
 # Sources & includes paths
 #
-SRCS += $(APP_SRCS_PATH)app.c
+SRCS += $(APP_SRCS_PATH)app.c 
+SRCS += $(APP_SRCS_PATH)fsm/fsm.c
+SRCS += $(APP_SRCS_PATH)data/meter/meter_data.c
+SRCS += $(APP_SRCS_PATH)data/token/token_injection_response.c
+SRCS += $(APP_SRCS_PATH)queues/queue.c
+SRCS += $(APP_SRCS_PATH)queues/token_injection_response_queue/token_injection_response_queue.c
+SRCS += $(APP_SRCS_PATH)utils/command_builder/command_builder.c 
+SRCS += $(APP_SRCS_PATH)utils/meter_hex_to_int/meter_hex_to_int.c 
+SRCS += $(APP_SRCS_PATH)utils/circular_buffer/circular_buffer.c
+SRCS += $(APP_SRCS_PATH)drivers/meter/enlight/enlight.c
+SRCS += $(APP_SRCS_PATH)drivers/time/delay_timer/delay_timer.c 
+SRCS += $(APP_SRCS_PATH)services/controllers/meter_controller/meter_controller.c 
+
 INCLUDES += -I$(API_PATH) -I$(APP_SRCS_PATH)include -I$(UTIL_PATH)
+INCLUDES += -I$(APP_SRCS_PATH)fsm
+INCLUDES += -I$(APP_SRCS_PATH)data/meter  
+INCLUDES += -I$(APP_SRCS_PATH)data/token
+INCLUDES += -I$(APP_SRCS_PATH)queues
+INCLUDES += -I$(APP_SRCS_PATH)queues/token_injection_response_queue
+INCLUDES += -I$(APP_SRCS_PATH)queues/token_recv_queue
+INCLUDES += -I$(APP_SRCS_PATH)utils/command_builder
+INCLUDES += -I$(APP_SRCS_PATH)utils/meter_hex_to_int
+INCLUDES += -I$(APP_SRCS_PATH)utils/circular_buffer
+INCLUDES += -I$(APP_SRCS_PATH)drivers/meter/enlight
+INCLUDES += -I$(APP_SRCS_PATH)drivers/time/delay_timer
+INCLUDES += -I$(APP_SRCS_PATH)services/controllers/meter_controller
+
 
 # Objects list
 OBJS_ = $(SRCS:.c=.o) $(ASM_SRCS:.s=.o)

--- a/mcu/hal_api/hal_api.h
+++ b/mcu/hal_api/hal_api.h
@@ -22,6 +22,9 @@
 // USART driver
 #include "usart.h"
 
+// USART2 driver
+#include "usart2.h"
+
 // Deep sleep control
 #include "ds.h"
 

--- a/mcu/hal_api/usart2.h
+++ b/mcu/hal_api/usart2.h
@@ -1,16 +1,26 @@
-#ifndef USART2_H_
-#define USART2_H_
+#ifndef _UART_H_
+#define _UART_H_
 
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
+#include "hal_api.h"
+
+
+#define UART_BUFFER_SIZE 256U
+/**
+ * @brief Flow control states
+ */
 typedef enum{
     UART2_FLOW_CONTROL_NONE,
     UART2_FLOW_CONTROL_HW,
 } uart2_flow_control_e;
 
-
+/**
+ * @brief UART operation errors
+ * 
+ */
 typedef enum {
     UART_OP_CONFIG_ERROR = -4,
     UART_OP_NO_DATA,
@@ -19,39 +29,82 @@ typedef enum {
     UART_OP_OK
 }uart_op_t;
 
-/**
- * @brief Initialize the UART port
- * 
- * @param baudrate 
- * @param flow_control 
- * @return int 
- */
-int usart2_init(uint32_t baudrate, unsigned int flow_control);
+typedef struct uart_cfg{
+    /* communication baud rate */
+    int baudrate;
+    /* UART port to use */
+    NRF_UARTE_Type* uart;
+    /* receive pin */
+    unsigned int rx_pin;
+    /* Transmit pin */
+    unsigned int tx_pin;
+    /* UART flow control */
+    unsigned int flow_control;
+}uart_cfg_t;
 
-/**
- * @brief Initialize RX and set the related callback
- * 
- * @return int operation error or the number of bytes received
- */
-int usart2_set_rx(void);
+/* Transmit buffer object */
+typedef struct {
+    uint8_t buffer[UART_BUFFER_SIZE];
+    int index;
+}tx_buffer_t;
 
-/**
- * @brief 
- * 
- * @param buf 
- * @param len 
- * @return uint32_t 
- */
-uint32_t usart2_tx(const void * buf, uint32_t len);
+typedef struct uart_t uart_t;
+struct uart_t {
+    /* UART configuration*/
+    uart_cfg_t cfg;
 
-/**
- * @brief 
- * 
- * @param data 
- * @param len 
- * @return int 
- */
-int usart2_rx(uint8_t* data, unsigned int len);
+    /* UART receive buffer*/
+    uint8_t rx_buffer[UART_BUFFER_SIZE];
+
+    /* UART transmit buffer */
+    tx_buffer_t tx_buffer;
+
+    /**
+     * @brief initialize the UART port
+     * @param self uart object
+     * @param cfg uart configuration
+     * @return int operaton status
+     */
+    int (*init)(struct uart_t *self, uart_cfg_t cfg);
+
+    /**
+     * @brief set the receive configuration of the UART
+     * @param self uart object
+     * @return int operation status
+     */
+    int (*set_rx)(struct uart_t *self);
+
+    /**
+     * @brief transmit data through UART port
+     * @param self uart object
+     * @param buf buffer containing data to transmit
+     * @param len length of the data to transmit
+     * @return error or number of bytes transmitted
+     * 
+     */
+    unsigned int (*tx)(struct uart_t *self, const void *buf, unsigned int len);
+
+    /**
+     * @brief Receive data though the UART port
+     * @param self uart object
+     * @param data buffer to store the received data
+     * @param len size of the receive buffer
+     * @return int error or number of bytes received
+     * 
+     */
+    int (*rx)(struct uart_t *self, uint8_t *data, unsigned int len);
+
+    /**
+     * @brief Clear the uart receive buffer
+     * @param self uart object
+     * @return int operation status
+     */
+    int (*clear_buffer)(struct uart_t *self);
+
+};
+
+/* Create a UART port */
+void uart_create(uart_t *self);
 
 
-#endif /* USART2_H_ */
+#endif // _UART_H_

--- a/mcu/hal_api/usart2.h
+++ b/mcu/hal_api/usart2.h
@@ -1,0 +1,57 @@
+#ifndef USART2_H_
+#define USART2_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+typedef enum{
+    UART2_FLOW_CONTROL_NONE,
+    UART2_FLOW_CONTROL_HW,
+} uart2_flow_control_e;
+
+
+typedef enum {
+    UART_OP_CONFIG_ERROR = -4,
+    UART_OP_NO_DATA,
+    UART_OP_DATA_ERROR,
+    UART_OP_ERROR,
+    UART_OP_OK
+}uart_op_t;
+
+/**
+ * @brief Initialize the UART port
+ * 
+ * @param baudrate 
+ * @param flow_control 
+ * @return int 
+ */
+int usart2_init(uint32_t baudrate, unsigned int flow_control);
+
+/**
+ * @brief Initialize RX and set the related callback
+ * 
+ * @return int operation error or the number of bytes received
+ */
+int usart2_set_rx(void);
+
+/**
+ * @brief 
+ * 
+ * @param buf 
+ * @param len 
+ * @return uint32_t 
+ */
+uint32_t usart2_tx(const void * buf, uint32_t len);
+
+/**
+ * @brief 
+ * 
+ * @param data 
+ * @param len 
+ * @return int 
+ */
+int usart2_rx(uint8_t* data, unsigned int len);
+
+
+#endif /* USART2_H_ */

--- a/mcu/nrf/nrf91/hal/makefile
+++ b/mcu/nrf/nrf91/hal/makefile
@@ -18,3 +18,6 @@ SRCS += $(NRF91_HAL_PREFIX)i2c.c
 endif
 
 SRCS += $(NRF91_HAL_PREFIX)power.c
+
+SRCS += $(NRF91_HAL_PREFIX)usart2_dma.c
+

--- a/mcu/nrf/nrf91/hal/usart2_dma.c
+++ b/mcu/nrf/nrf91/hal/usart2_dma.c
@@ -155,7 +155,7 @@ int usart2_clear_buffer(void){
     while(NRF_UARTE1->EVENTS_RXTO != 1){}
 
     /* Clear buffer*/
-    memset(usart2_m_rx_buffer, 0, sizeof(rx_buffer));
+    memset(usart2_m_rx_buffer, 0, sizeof(usart2_m_rx_buffer));
 
     /* Start RX*/
     NRF_UARTE1->EVENTS_RXSTARTED = 0;

--- a/mcu/nrf/nrf91/hal/usart2_dma.c
+++ b/mcu/nrf/nrf91/hal/usart2_dma.c
@@ -1,278 +1,227 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
-
 #include "board.h"
 #include "hal_api.h"
 #include "api.h"
 
-/** Declare buffer size (defined by max DMA transfert size) */
-#define BUFFER_SIZE 256u
-#include "doublebuffer.h"
+#define DEBUG_LOG_MODULE_NAME "USART M"
+#define DEBUG_LOG_MAX_LEVEL LVL_INFO
+#include "debug_log.h"
 
-/* Size of the RX Buffer */
-#define SYS_RX_BUFFER_SIZE 256
-/* Buffer to receive UART bytes */
-uint8_t usart2_m_rx_buffer[SYS_RX_BUFFER_SIZE];
+/* Private function declarations */
+static bool usart2_set_baud(uart_t *self);
+static int usart2_init_dma(uart_t *self);
+static int usart2_start_tx_lock(uart_t *self);
+static int usart2_set_rx(uart_t *self);
 
-/* Buffers used for transmission */
-static double_buffer_t usart2_m_tx_buffers;
+/* Method implementations */
+static int usart2_init(uart_t *self, uart_cfg_t cfg) {
 
-/** Set uarte baudrate */
-static bool usart2_set_baud(uint32_t baudrate);
-
-/** Initialize DMA part */
-static int usart2_init_dma(uint32_t baudrate);
-
-/** Called each time a transfer is ready or when a previous transfer was finished. This function must be called with interrupts
- *  disabled or from interrupt context
- */
-static int usart2_start_tx_lock(void);
-
-int usart2_init(uint32_t baudrate, unsigned int flow_control)
-{
-
-    nrf_gpio_cfg_default(BOARD_USART2_TX_PIN);
-    nrf_gpio_pin_set(BOARD_USART2_TX_PIN);
-    nrf_gpio_cfg_default(BOARD_USART2_RX_PIN);
-    nrf_gpio_pin_set(BOARD_USART2_RX_PIN);
-
-    /* Ensue UART is disables before configuration*/
-    NRF_UARTE1->ENABLE = UARTE_ENABLE_ENABLE_Disabled;
-
-    /* Set the pins to be used for UART TX and RX*/
-    NRF_UARTE1->PSEL.TXD = BOARD_USART2_TX_PIN;
-    NRF_UARTE1->PSEL.RXD = BOARD_USART2_RX_PIN;
-    NRF_UARTE1->TASKS_STOPTX = 1;
-    NRF_UARTE1->TASKS_STOPRX = 1;
-
-    /* Set the UART communication baudrate */
-    if(!usart2_set_baud(baudrate)){
+    if(self == NULL){
         return UART_OP_CONFIG_ERROR;
     }
 
-    /* Initialize DMA p0rt*/
-    if(usart2_init_dma(baudrate) != UART_OP_OK){
+    self->cfg = cfg;
+
+    nrf_gpio_cfg_default(self->cfg.tx_pin);
+    nrf_gpio_pin_set(self->cfg.tx_pin);
+    // nrf_gpio_cfg_default(self->cfg.rx_pin);
+    // nrf_gpio_pin_set(self->cfg.rx_pin);
+
+    self->cfg.uart->ENABLE = UARTE_ENABLE_ENABLE_Disabled;
+    self->cfg.uart->PSEL.TXD = self->cfg.tx_pin;
+    self->cfg.uart->PSEL.RXD = self->cfg.rx_pin;
+    self->cfg.uart->TASKS_STOPTX = 1;
+    self->cfg.uart->TASKS_STOPRX = 1;
+
+    if (!usart2_set_baud(self)) {
         return UART_OP_CONFIG_ERROR;
     }
 
-    /* Configure TX pin and Enable UART*/
-    nrf_gpio_cfg(BOARD_USART2_TX_PIN,
-                         NRF_GPIO_PIN_DIR_OUTPUT,
-                         NRF_GPIO_PIN_INPUT_CONNECT,
-                         NRF_GPIO_PIN_NOPULL,
-                         NRF_GPIO_PIN_S0S1,
-                         NRF_GPIO_PIN_NOSENSE);
-
-    NRF_UARTE1->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
-
-    /* Set rx parameters for the UART */
-    if(usart2_set_rx() != UART_OP_OK){
+    if (usart2_init_dma(self) != UART_OP_OK) {
         return UART_OP_CONFIG_ERROR;
     }
+
+    nrf_gpio_cfg(self->cfg.tx_pin,
+                 NRF_GPIO_PIN_DIR_OUTPUT,
+                 NRF_GPIO_PIN_INPUT_CONNECT,
+                 NRF_GPIO_PIN_NOPULL,
+                 NRF_GPIO_PIN_S0S1,
+                 NRF_GPIO_PIN_NOSENSE);
+
+    
+
+    self->cfg.uart->CONFIG = 0;
+
+    if (usart2_set_rx(self) != UART_OP_OK) {
+        return UART_OP_CONFIG_ERROR;
+    }
+
+    self->cfg.uart->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
 
     return UART_OP_OK;
 }
 
-int usart2_set_rx(void){
+static int usart2_set_rx(uart_t *self) {
 
     Sys_enterCriticalSection();
 
-    /* Enable RX input */
-    nrf_gpio_cfg(BOARD_USART2_RX_PIN,
-                     NRF_GPIO_PIN_DIR_INPUT,
-                     NRF_GPIO_PIN_INPUT_CONNECT,
-                     NRF_GPIO_PIN_NOPULL,
-                     NRF_GPIO_PIN_S0S1,
-                     NRF_GPIO_PIN_SENSE_LOW);
-    
-    /* Clear all active events */
-    NRF_UARTE1->EVENTS_RXDRDY = 0;
-    NRF_UARTE1->EVENTS_ENDRX = 0;
-    NRF_UARTE1->EVENTS_RXSTARTED = 0;
+    nrf_gpio_cfg(self->cfg.rx_pin,
+                 NRF_GPIO_PIN_DIR_INPUT,
+                 NRF_GPIO_PIN_INPUT_CONNECT,
+                 NRF_GPIO_PIN_PULLUP,
+                 NRF_GPIO_PIN_S0S1,
+                 NRF_GPIO_PIN_SENSE_LOW);
 
-    // Prepare RX buffer
-    NRF_UARTE1->RXD.PTR = (uint32_t) usart2_m_rx_buffer;
-    NRF_UARTE1->RXD.MAXCNT = SYS_RX_BUFFER_SIZE;
+    self->cfg.uart->EVENTS_RXDRDY = 0;
+    self->cfg.uart->EVENTS_ENDRX = 0;
+    self->cfg.uart->EVENTS_RXSTARTED = 0;
 
-    /*Start the Uart again */
-    NRF_UARTE1->EVENTS_RXSTARTED = 0;
-    NRF_UARTE1->TASKS_STARTRX = 1;
-
-    // Confirm that the reception has been started again */
-    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
-
+    self->cfg.uart->RXD.PTR = (uint32_t) self->rx_buffer;
+    self->cfg.uart->RXD.MAXCNT = UART_BUFFER_SIZE;
 
     Sys_exitCriticalSection();
 
     return UART_OP_OK;
 }
 
-int usart2_rx(uint8_t* data, unsigned int len){
+static int usart2_clear_buffer(uart_t *self) {
 
     Sys_enterCriticalSection();
 
-    /* Stop data reception */
-    NRF_UARTE1->TASKS_STOPRX = 1;
+    self->cfg.uart->TASKS_STOPRX = 1;
 
-    /* Wait for the reception to stop*/
-    while(NRF_UARTE1->EVENTS_ENDRX != 1){}
+    while (self->cfg.uart->EVENTS_RXTO != 1) {}
 
-    /**
-     * For some reason the RXD.AMOUNT Register still returns zero at this point
-     * @todo Find out why and use it to get the number of bytes received.
-     */
+    memset(self->rx_buffer, 0, sizeof(self->rx_buffer));
 
-    int bytes = (int) strlen((const char*) usart2_m_rx_buffer);
+    self->cfg.uart->RXD.PTR = (uint32_t) self->rx_buffer;
+    self->cfg.uart->RXD.MAXCNT = UART_BUFFER_SIZE;
 
-    if(bytes == 0 ){
+    self->cfg.uart->TASKS_STARTRX = 1;
+
+    while (self->cfg.uart->EVENTS_RXSTARTED != 1) {}
+
+    Sys_exitCriticalSection();
+
+    return UART_OP_OK;
+}
+
+static unsigned int usart2_tx(uart_t *self, const void *buffer, unsigned int length) {
+
+    Sys_enterCriticalSection();
+
+    if (usart2_clear_buffer(self) != UART_OP_OK) {
+        Sys_exitCriticalSection();
+        return 0;
+    }
+
+    if(length > UART_BUFFER_SIZE){
+        Sys_exitCriticalSection();
+        return 0;
+    }
+    memcpy(self->tx_buffer.buffer,
+           buffer,
+           length);
+
+    self->tx_buffer.index = length;
+
+    int ret = usart2_start_tx_lock(self);
+
+    Sys_exitCriticalSection();
+
+    return ret;
+}
+
+static int usart2_rx(uart_t *self, uint8_t *data, unsigned int len) {
+
+    Sys_enterCriticalSection();
+
+    self->cfg.uart->TASKS_STOPRX = 1;
+
+    while (self->cfg.uart->EVENTS_ENDRX != 1) {}
+
+    int bytes = (int) strlen((const char*) self->rx_buffer);
+
+    if (bytes == 0) {
         Sys_exitCriticalSection();
         return UART_OP_NO_DATA;
     }
 
-    /* Copy the received bytes from the rx_buffer to user buffer */
-    memcpy(data, usart2_m_rx_buffer, bytes);
+    memcpy(data, self->rx_buffer, bytes);
 
-    /*Start the Uart again */
-    NRF_UARTE1->EVENTS_RXSTARTED = 0;
-    NRF_UARTE1->TASKS_STARTRX = 1;
+    self->cfg.uart->TASKS_STARTRX = 1;
 
-    /* Confirm that the reception has been started again */
-    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
+    while (self->cfg.uart->EVENTS_RXSTARTED != 1) {}
 
     Sys_exitCriticalSection();
 
     return bytes;
-
 }
 
-int usart2_clear_buffer(void){
+static bool usart2_set_baud(uart_t *self) {
 
-    Sys_enterCriticalSection();
+    switch (self->cfg.baudrate) {
+        case 115200:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud115200;
+            break;
+        case 125000:
+            self->cfg.uart->BAUDRATE = (uint32_t)(0x02000000UL);
+            break;
+        case 250000:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud250000;
+            break;
+        case 460800:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud460800;
+            break;
+        case 1000000:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud1M;
+            break;
+        case 2400:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud2400;
+            break; 
+        case 9600:
+            self->cfg.uart->BAUDRATE = (uint32_t) UARTE_BAUDRATE_BAUDRATE_Baud9600;
+            break; 
+        default:
+            return false;
+    };
 
-    /* Stop RX */
-    NRF_UARTE1->TASKS_STOPRX = 1;
-    while(NRF_UARTE1->EVENTS_RXTO != 1){}
-
-    /* Clear buffer*/
-    memset(usart2_m_rx_buffer, 0, sizeof(usart2_m_rx_buffer));
-
-    /* Start RX*/
-    NRF_UARTE1->EVENTS_RXSTARTED = 0;
-    NRF_UARTE1->TASKS_STARTRX = 1;
-
-    /* Confirm that the reception has been started again */
-    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
-
-    Sys_exitCriticalSection();
-
-    return UART_OP_OK;
+    return true;
 }
 
-uint32_t usart2_tx(const void * buffer, uint32_t length)
-{
-    Sys_enterCriticalSection();
+static int usart2_init_dma(uart_t *self) {
 
-    if(usart2_clear_buffer() != UART_OP_OK){
-        return 0;
-    }
+    self->cfg.uart->INTENCLR = 0xffffffffUL;
 
-    // Check if there is enough room
-    if (BUFFER_SIZE - DoubleBuffer_getIndex(usart2_m_tx_buffers) < length)
-    {
-        Sys_exitCriticalSection();
-        return 0;
-    }
-
-    // Copy data to current buffer
-    memcpy(DoubleBuffer_getActive(usart2_m_tx_buffers) +
-           DoubleBuffer_getIndex(usart2_m_tx_buffers),
-           buffer,
-           length);
-
-    DoubleBuffer_incrIndex(usart2_m_tx_buffers, length);
-
-    int ret =  usart2_start_tx_lock();
-
-    Sys_exitCriticalSection();
-
-    return ret;
-}
-
-static int usart2_start_tx_lock(void)
-{
-
-    if (DoubleBuffer_getIndex(usart2_m_tx_buffers) == 0)
-    {
-        // Nothing to send
-        return -1;
-    }
-
-    // Start DMA
-    NRF_UARTE1->TXD.PTR = (uint32_t) DoubleBuffer_getActive(usart2_m_tx_buffers);
-    NRF_UARTE1->TXD.MAXCNT = DoubleBuffer_getIndex(usart2_m_tx_buffers);
-
-    NRF_UARTE1->EVENTS_ENDTX = 0;
-    NRF_UARTE1->TASKS_STARTTX = 1;
-
-    /* Wait for the transmission to complete */
-    while(NRF_UARTE1->EVENTS_ENDTX == 0){}
-
-    // Swipe buffers (it automatically reset writing index)
-    DoubleBuffer_swipe(usart2_m_tx_buffers);
-
-    /** Return number of bytes transmitted  */
-    return NRF_UARTE1->TXD.AMOUNT;
-}
-
-
-static bool usart2_set_baud(uint32_t baudrate)
-{
-    bool ret = true;
-    switch (baudrate)
-    {
-    case 115200:
-        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud115200;
-        break;
-    case 125000:
-        // This value is not from official nrf9160_bitfields.h
-        NRF_UARTE1->BAUDRATE = (uint32_t)(0x02000000UL);
-        break;
-    case 250000:
-        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud250000;
-        break;
-    case 460800:
-        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud460800;
-        break;
-    case 1000000:
-        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud1M;
-        break;
-    default:
-        // Intended baudrate is not in the list, default baudrate from chip will be used
-        ret = false;
-        break;
-    }
-
-    return ret;
-}
-
-static int usart2_init_dma(uint32_t baudrate)
-{
-
-    NRF_UARTE1->INTENCLR = 0xffffffffUL;
-    NRF_UARTE1->INTENSET =
+    self->cfg.uart->INTENSET =
         (UARTE_INTEN_ENDTX_Enabled << UARTE_INTEN_ENDTX_Pos) |
         (UARTE_INTEN_ERROR_Enabled << UARTE_INTEN_ERROR_Pos);
 
-    NRF_UARTE0->SHORTS =
-        UARTE_SHORTS_ENDRX_STARTRX_Enabled << UARTE_SHORTS_ENDRX_STARTRX_Pos;
- 
-    /* Configure TX part */
-    DoubleBuffer_init(usart2_m_tx_buffers);
-
-    if(DoubleBuffer_getIndex(usart2_m_tx_buffers) != 0){
-        return UART_OP_CONFIG_ERROR;
-    }
-
     return UART_OP_OK;
+}
+
+static int usart2_start_tx_lock(uart_t *self) {
+
+    self->cfg.uart->TXD.PTR = (uint32_t) self->tx_buffer.buffer;
+    self->cfg.uart->TXD.MAXCNT = self->tx_buffer.index;
+
+    self->cfg.uart->EVENTS_ENDTX = 0;
+    self->cfg.uart->TASKS_STARTTX = 1;
+
+    while (self->cfg.uart->EVENTS_ENDTX == 0) {}
+
+    return self->cfg.uart->TXD.AMOUNT;
+}
+
+/* Function to initialize method pointers */
+void uart_create(uart_t *self) {
+
+    self->init = usart2_init;
+    self->set_rx = usart2_set_rx;
+    self->tx = usart2_tx;
+    self->rx = usart2_rx;
+    self->clear_buffer = usart2_clear_buffer;
+
 }

--- a/mcu/nrf/nrf91/hal/usart2_dma.c
+++ b/mcu/nrf/nrf91/hal/usart2_dma.c
@@ -1,0 +1,278 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "board.h"
+#include "hal_api.h"
+#include "api.h"
+
+/** Declare buffer size (defined by max DMA transfert size) */
+#define BUFFER_SIZE 256u
+#include "doublebuffer.h"
+
+/* Size of the RX Buffer */
+#define SYS_RX_BUFFER_SIZE 256
+/* Buffer to receive UART bytes */
+uint8_t usart2_m_rx_buffer[SYS_RX_BUFFER_SIZE];
+
+/* Buffers used for transmission */
+static double_buffer_t usart2_m_tx_buffers;
+
+/** Set uarte baudrate */
+static bool usart2_set_baud(uint32_t baudrate);
+
+/** Initialize DMA part */
+static int usart2_init_dma(uint32_t baudrate);
+
+/** Called each time a transfer is ready or when a previous transfer was finished. This function must be called with interrupts
+ *  disabled or from interrupt context
+ */
+static int usart2_start_tx_lock(void);
+
+int usart2_init(uint32_t baudrate, unsigned int flow_control)
+{
+
+    nrf_gpio_cfg_default(BOARD_USART2_TX_PIN);
+    nrf_gpio_pin_set(BOARD_USART2_TX_PIN);
+    nrf_gpio_cfg_default(BOARD_USART2_RX_PIN);
+    nrf_gpio_pin_set(BOARD_USART2_RX_PIN);
+
+    /* Ensue UART is disables before configuration*/
+    NRF_UARTE1->ENABLE = UARTE_ENABLE_ENABLE_Disabled;
+
+    /* Set the pins to be used for UART TX and RX*/
+    NRF_UARTE1->PSEL.TXD = BOARD_USART2_TX_PIN;
+    NRF_UARTE1->PSEL.RXD = BOARD_USART2_RX_PIN;
+    NRF_UARTE1->TASKS_STOPTX = 1;
+    NRF_UARTE1->TASKS_STOPRX = 1;
+
+    /* Set the UART communication baudrate */
+    if(!usart2_set_baud(baudrate)){
+        return UART_OP_CONFIG_ERROR;
+    }
+
+    /* Initialize DMA p0rt*/
+    if(usart2_init_dma(baudrate) != UART_OP_OK){
+        return UART_OP_CONFIG_ERROR;
+    }
+
+    /* Configure TX pin and Enable UART*/
+    nrf_gpio_cfg(BOARD_USART2_TX_PIN,
+                         NRF_GPIO_PIN_DIR_OUTPUT,
+                         NRF_GPIO_PIN_INPUT_CONNECT,
+                         NRF_GPIO_PIN_NOPULL,
+                         NRF_GPIO_PIN_S0S1,
+                         NRF_GPIO_PIN_NOSENSE);
+
+    NRF_UARTE1->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
+
+    /* Set rx parameters for the UART */
+    if(usart2_set_rx() != UART_OP_OK){
+        return UART_OP_CONFIG_ERROR;
+    }
+
+    return UART_OP_OK;
+}
+
+int usart2_set_rx(void){
+
+    Sys_enterCriticalSection();
+
+    /* Enable RX input */
+    nrf_gpio_cfg(BOARD_USART2_RX_PIN,
+                     NRF_GPIO_PIN_DIR_INPUT,
+                     NRF_GPIO_PIN_INPUT_CONNECT,
+                     NRF_GPIO_PIN_NOPULL,
+                     NRF_GPIO_PIN_S0S1,
+                     NRF_GPIO_PIN_SENSE_LOW);
+    
+    /* Clear all active events */
+    NRF_UARTE1->EVENTS_RXDRDY = 0;
+    NRF_UARTE1->EVENTS_ENDRX = 0;
+    NRF_UARTE1->EVENTS_RXSTARTED = 0;
+
+    // Prepare RX buffer
+    NRF_UARTE1->RXD.PTR = (uint32_t) usart2_m_rx_buffer;
+    NRF_UARTE1->RXD.MAXCNT = SYS_RX_BUFFER_SIZE;
+
+    /*Start the Uart again */
+    NRF_UARTE1->EVENTS_RXSTARTED = 0;
+    NRF_UARTE1->TASKS_STARTRX = 1;
+
+    // Confirm that the reception has been started again */
+    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
+
+
+    Sys_exitCriticalSection();
+
+    return UART_OP_OK;
+}
+
+int usart2_rx(uint8_t* data, unsigned int len){
+
+    Sys_enterCriticalSection();
+
+    /* Stop data reception */
+    NRF_UARTE1->TASKS_STOPRX = 1;
+
+    /* Wait for the reception to stop*/
+    while(NRF_UARTE1->EVENTS_ENDRX != 1){}
+
+    /**
+     * For some reason the RXD.AMOUNT Register still returns zero at this point
+     * @todo Find out why and use it to get the number of bytes received.
+     */
+
+    int bytes = (int) strlen((const char*) usart2_m_rx_buffer);
+
+    if(bytes == 0 ){
+        Sys_exitCriticalSection();
+        return UART_OP_NO_DATA;
+    }
+
+    /* Copy the received bytes from the rx_buffer to user buffer */
+    memcpy(data, usart2_m_rx_buffer, bytes);
+
+    /*Start the Uart again */
+    NRF_UARTE1->EVENTS_RXSTARTED = 0;
+    NRF_UARTE1->TASKS_STARTRX = 1;
+
+    /* Confirm that the reception has been started again */
+    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
+
+    Sys_exitCriticalSection();
+
+    return bytes;
+
+}
+
+int usart2_clear_buffer(void){
+
+    Sys_enterCriticalSection();
+
+    /* Stop RX */
+    NRF_UARTE1->TASKS_STOPRX = 1;
+    while(NRF_UARTE1->EVENTS_RXTO != 1){}
+
+    /* Clear buffer*/
+    memset(usart2_m_rx_buffer, 0, sizeof(rx_buffer));
+
+    /* Start RX*/
+    NRF_UARTE1->EVENTS_RXSTARTED = 0;
+    NRF_UARTE1->TASKS_STARTRX = 1;
+
+    /* Confirm that the reception has been started again */
+    while(NRF_UARTE1->EVENTS_RXSTARTED != 1){}
+
+    Sys_exitCriticalSection();
+
+    return UART_OP_OK;
+}
+
+uint32_t usart2_tx(const void * buffer, uint32_t length)
+{
+    Sys_enterCriticalSection();
+
+    if(usart2_clear_buffer() != UART_OP_OK){
+        return 0;
+    }
+
+    // Check if there is enough room
+    if (BUFFER_SIZE - DoubleBuffer_getIndex(usart2_m_tx_buffers) < length)
+    {
+        Sys_exitCriticalSection();
+        return 0;
+    }
+
+    // Copy data to current buffer
+    memcpy(DoubleBuffer_getActive(usart2_m_tx_buffers) +
+           DoubleBuffer_getIndex(usart2_m_tx_buffers),
+           buffer,
+           length);
+
+    DoubleBuffer_incrIndex(usart2_m_tx_buffers, length);
+
+    int ret =  usart2_start_tx_lock();
+
+    Sys_exitCriticalSection();
+
+    return ret;
+}
+
+static int usart2_start_tx_lock(void)
+{
+
+    if (DoubleBuffer_getIndex(usart2_m_tx_buffers) == 0)
+    {
+        // Nothing to send
+        return -1;
+    }
+
+    // Start DMA
+    NRF_UARTE1->TXD.PTR = (uint32_t) DoubleBuffer_getActive(usart2_m_tx_buffers);
+    NRF_UARTE1->TXD.MAXCNT = DoubleBuffer_getIndex(usart2_m_tx_buffers);
+
+    NRF_UARTE1->EVENTS_ENDTX = 0;
+    NRF_UARTE1->TASKS_STARTTX = 1;
+
+    /* Wait for the transmission to complete */
+    while(NRF_UARTE1->EVENTS_ENDTX == 0){}
+
+    // Swipe buffers (it automatically reset writing index)
+    DoubleBuffer_swipe(usart2_m_tx_buffers);
+
+    /** Return number of bytes transmitted  */
+    return NRF_UARTE1->TXD.AMOUNT;
+}
+
+
+static bool usart2_set_baud(uint32_t baudrate)
+{
+    bool ret = true;
+    switch (baudrate)
+    {
+    case 115200:
+        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud115200;
+        break;
+    case 125000:
+        // This value is not from official nrf9160_bitfields.h
+        NRF_UARTE1->BAUDRATE = (uint32_t)(0x02000000UL);
+        break;
+    case 250000:
+        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud250000;
+        break;
+    case 460800:
+        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud460800;
+        break;
+    case 1000000:
+        NRF_UARTE1->BAUDRATE = (uint32_t)UARTE_BAUDRATE_BAUDRATE_Baud1M;
+        break;
+    default:
+        // Intended baudrate is not in the list, default baudrate from chip will be used
+        ret = false;
+        break;
+    }
+
+    return ret;
+}
+
+static int usart2_init_dma(uint32_t baudrate)
+{
+
+    NRF_UARTE1->INTENCLR = 0xffffffffUL;
+    NRF_UARTE1->INTENSET =
+        (UARTE_INTEN_ENDTX_Enabled << UARTE_INTEN_ENDTX_Pos) |
+        (UARTE_INTEN_ERROR_Enabled << UARTE_INTEN_ERROR_Pos);
+
+    NRF_UARTE0->SHORTS =
+        UARTE_SHORTS_ENDRX_STARTRX_Enabled << UARTE_SHORTS_ENDRX_STARTRX_Pos;
+ 
+    /* Configure TX part */
+    DoubleBuffer_init(usart2_m_tx_buffers);
+
+    if(DoubleBuffer_getIndex(usart2_m_tx_buffers) != 0){
+        return UART_OP_CONFIG_ERROR;
+    }
+
+    return UART_OP_OK;
+}

--- a/source/example_apps/evaluation_app/data/meter/meter_data.c
+++ b/source/example_apps/evaluation_app/data/meter/meter_data.c
@@ -1,0 +1,7 @@
+#include <meter_data.h>
+
+static meter_data_t default_meter_data;
+
+meter_data_t* get_meter_data_instance(){
+    return &default_meter_data;
+}

--- a/source/example_apps/evaluation_app/data/meter/meter_data.h
+++ b/source/example_apps/evaluation_app/data/meter/meter_data.h
@@ -1,0 +1,38 @@
+#ifndef _METER_DATA_H
+#define _METER_DATA_H
+
+#include <stdint.h>
+
+typedef struct meter_data {
+
+    int start_x;
+
+    int device_type; //4
+    int producer; //4
+    int billing_type;//4
+
+    uint64_t serial;
+
+    int supply_group;//4
+    int meter_status;
+    int tamper_status;
+    int power_limit;
+
+    int kwh_consumed;
+    int kwh_forward;
+    int kwh_reverse;
+    int peak_demand;
+    int available_credit;
+    int time_stamp;
+
+    int end_x;
+
+}meter_data_t;
+
+meter_data_t* get_meter_data_instance();
+
+
+
+
+
+#endif //_METER_DATA_H

--- a/source/example_apps/evaluation_app/data/token/token_injection_response.c
+++ b/source/example_apps/evaluation_app/data/token/token_injection_response.c
@@ -1,0 +1,7 @@
+#include <token_injection_response.h>
+
+static token_injection_response_t default_response;
+
+token_injection_response_t* get_token_response_data_instance(){
+    return &default_response;
+}

--- a/source/example_apps/evaluation_app/data/token/token_injection_response.h
+++ b/source/example_apps/evaluation_app/data/token/token_injection_response.h
@@ -1,0 +1,28 @@
+#ifndef _TOKEN_INJECTION_RESPONSE_H
+#define _TOKEN_INJECTION_REsPONSE_H
+
+#include <stdint.h>
+
+
+
+typedef struct token_injection_response{
+
+    int start_x;
+
+    uint64_t serial;
+
+    int injected_units;
+    int operation_status;
+
+    int is_valid;
+
+    int end_x;
+
+}token_injection_response_t;
+
+
+token_injection_response_t* get_token_response_data_instance();
+
+
+
+#endif //_TOKEN_INJECTION_RESPONSE_H

--- a/source/example_apps/evaluation_app/drivers/meter/enlight/enlight.c
+++ b/source/example_apps/evaluation_app/drivers/meter/enlight/enlight.c
@@ -1,0 +1,387 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <enlight.h>
+#include <command_builder.h>
+#include <meter_hex_to_int.h>
+#include <board.h>
+
+#include <delay_timer.h>
+
+// #include "payload_parser.h"
+#include "meter_data.h"
+
+#define DEBUG_LOG_MODULE_NAME "ENLIGHT M"
+#define DEBUG_LOG_MAX_LEVEL LVL_INFO
+#include "debug_log.h"
+
+#define REALTIME_READ_REGISTERS_NUM 2
+
+/**
+ * @brief List of commands to get information from meter
+ */
+uint8_t meter_info_commands[5][10] = {
+    {0x01, 0x52, 0x02, 0x32, 0x30, 0x30, 0x36, 0x30, 0x03, 0x67}, // Meter Serial Number
+    {0x01, 0x52, 0x02, 0x32, 0x30, 0x30, 0x32, 0x30, 0x03, 0x63}, // Meter status
+    {0x01, 0x52, 0x02, 0x32, 0x30, 0x31, 0x34, 0x30, 0x03, 0x64}, // Tamper Status
+    {0x01, 0x52, 0x02, 0x32, 0x30, 0x31, 0x36, 0x30, 0x03, 0x66}, // Supply Group Code
+    {0x01, 0x52, 0x02, 0x32, 0x30, 0x30, 0x43, 0x30, 0x03, 0x12}, // Maximum Power Limit
+};
+
+/**
+ * @brief Address of registers to be read from the meter
+ */
+const uint16_t realtime_read_registers[REALTIME_READ_REGISTERS_NUM] = {
+    0x2011, /* CumulativeEnergyConsumption */
+    0x2010  /* AvailableElectricityCredit */
+};
+
+const uint16_t METER_TOKEN_ADDRESS = 0xFFFF;
+
+
+/* Private method prototypes */
+static int energy_meter_write(meter_t* self, char* command, uint8_t len);
+static int energy_meter_read(meter_t* self, char* buffer, uint8_t len);
+static int energy_meter_read_meter_address(meter_t* self, uint16_t address, char* rx_buffer, uint8_t size);
+static int energy_meter_write_meter_address(meter_t* self, uint16_t address, char* data, char* rx_buffer, uint8_t size);
+static int energy_meter_write_token(meter_t* self, char* token);
+
+/* utilities */
+static void energy_meter_encode_data(uint8_t* buffer, int len);
+static void energy_meter_decode_data(uint8_t* buffer, int len);
+static uint8_t energy_meter_calculate_parity(uint8_t data);
+
+static int energy_meter_init(meter_t* self) {
+
+    uart_create(&self->meter_interface);
+
+    uart_cfg_t cfg = {
+        .baudrate = 2400,
+        .uart = NRF_UARTE1,
+        .rx_pin = BOARD_USART2_RX_PIN,
+        .tx_pin = BOARD_USART2_TX_PIN,
+        .flow_control = UART2_FLOW_CONTROL_NONE,
+    };
+
+    if(self->meter_interface.init(&self->meter_interface, cfg) != UART_OP_OK){
+        LOG(LVL_ERROR, "Error initializing meter UART");
+        return METER_OP_CONFIG_ERROR;
+    }
+
+    /** Initialize the descriptive info about the meter */
+    get_meter_data_instance()->device_type = 0x01;
+    get_meter_data_instance()->producer = 0x01;
+    get_meter_data_instance()->billing_type = 0x01;
+
+    get_meter_data_instance()->start_x = 0xc0ffeeb0;
+    get_meter_data_instance()->end_x = 0xd0ffeeb0;
+
+    get_meter_data_instance()->serial = 0x09000030000;
+    // get_meter_data_instance()->meter_status = 0x0F;
+    // get_meter_data_instance()->supply_group = 0x00;
+    // get_meter_data_instance()->tamper_status = 0x00;
+    // get_meter_data_instance()->power_limit = 0x47e0;
+
+    // get_meter_data_instance()->kwh_consumed = 50;
+    // get_meter_data_instance()->available_credit = 29;
+    // get_meter_data_instance()->kwh_forward = 0;
+    // get_meter_data_instance()->kwh_reverse = 0;
+    // get_meter_data_instance()->peak_demand = 0;
+    // get_meter_data_instance()->time_stamp = 0;
+
+    return METER_OP_OK; // Success
+}
+
+static int energy_meter_fetch_sensor_data(meter_t* self, meter_data_req_t req) {
+    
+    int ret = energy_meter_write(self, req.command, req.command_len);
+
+	if (ret != req.command_len){
+		LOG(LVL_ERROR, "Command not sent\n");
+		return METER_OP_ERROR;
+	}
+	
+
+    for(volatile uint64_t i = 0; i < 2000000 ; i++){};
+  
+
+
+	ret = energy_meter_read(self, req.buffer, req.buffer_size);
+
+	if(ret <=  0){
+        LOG(LVL_ERROR, "No response from meter, check connection\n");
+		return METER_OP_ERROR;
+	}
+
+	/* null terminate the buffer */
+	req.buffer[ret] = '\0';
+
+    return ret;
+}
+
+static int energy_meter_configure(meter_t* self) {
+
+    char recv_buffer[5][ENERGY_METER_RX_BUFFER_SIZE];
+	
+	for(int i = 0; i < 5; i++){
+
+
+		meter_data_req_t req = {
+			.command 		= (char*) meter_info_commands[i],
+			.command_len 	= sizeof(meter_info_commands[i]),
+			.buffer 		= recv_buffer[i],
+			.buffer_size 	= ENERGY_METER_RX_BUFFER_SIZE
+		};
+
+		int ret = energy_meter_fetch_sensor_data(self, req);
+
+		if( ret <= 0){
+			return METER_OP_ERROR;
+		}
+	}
+
+    get_meter_data_instance()->serial = extract_hex_value(recv_buffer[0]);
+    get_meter_data_instance()->meter_status = extract_hex_value(recv_buffer[1]);
+    get_meter_data_instance()->tamper_status = extract_hex_value(recv_buffer[2]);
+    get_meter_data_instance()->supply_group = extract_hex_value(recv_buffer[3]);
+    get_meter_data_instance()->power_limit = extract_hex_value(recv_buffer[4]);
+
+	return METER_OP_OK;
+
+}
+
+static int energy_meter_update_realtime_data(meter_t* self) {
+   /** Read the provided registers and update json payload */
+	char data_receive_buffer[2][ENERGY_METER_RX_BUFFER_SIZE];
+
+	for(int i = 0; i < REALTIME_READ_REGISTERS_NUM; i++){
+
+		if(energy_meter_read_meter_address(self, realtime_read_registers[i], data_receive_buffer[i], sizeof(data_receive_buffer[i])) != METER_OP_OK){
+			return METER_OP_ERROR;
+		}
+		
+	}
+
+    get_meter_data_instance()->kwh_consumed = extract_hex_value(data_receive_buffer[0]) * 0.1;
+    get_meter_data_instance()->available_credit = extract_hex_value(data_receive_buffer[1]) * 0.1;
+    get_meter_data_instance()->kwh_forward = 0;
+    get_meter_data_instance()->kwh_reverse = 0;
+    get_meter_data_instance()->peak_demand = 0;
+	
+	return METER_OP_OK;
+}
+
+static int energy_meter_token_injection_tx(meter_t* self, token_injection_ctx* ctx) {
+
+    ctx->timestamp = 0;
+
+    /* Validate the meter UID sent with the token */
+    if( ctx->serial != get_meter_data_instance()->serial){
+        ctx->tx_status = METER_TOKEN_INJECTION_FAIL;
+        return METER_OP_ERROR;
+    }
+
+    /* Read the current meter available credits */
+    if (energy_meter_update_realtime_data(self) != METER_OP_OK) {
+        ctx->tx_status = METER_TOKEN_INJECTION_FAIL;
+        return METER_OP_ERROR;
+    }
+
+    ctx->units_before_injection = get_meter_data_instance()->available_credit;
+
+    /* Inject the received tokens */
+    if (energy_meter_write_token(self, ctx->token) != METER_RESPONSE_ACK) {
+        ctx->tx_status = METER_TOKEN_INJECTION_FAIL;
+        return METER_OP_ERROR;
+    }
+
+    /* Read the available credits after injection */
+    if (energy_meter_update_realtime_data(self) != METER_OP_OK) {
+        ctx->tx_status = METER_TOKEN_INJECTION_FAIL;
+        return METER_OP_ERROR;
+    }
+
+    ctx->units_after_injection = get_meter_data_instance()->available_credit;
+
+    /* Calculate the token value */
+    ctx->injected_tokens = ctx->units_after_injection - ctx->units_before_injection;
+
+    if (ctx->injected_tokens <= 0) {
+        ctx->tx_status = METER_TOKEN_INJECTION_FAIL;
+        return METER_OP_ERROR;
+    }
+
+    /* Set tx status */
+    ctx->tx_status = METER_TOKEN_INJECTION_SUCCESS;
+
+    return METER_OP_OK;
+}
+
+#ifdef SIMULATE_METER_DATA
+static int energy_meter_generate_realtime_data(meter_t* self, simulated_realtime_data_t* data) {
+    // Simulate real-time meter data
+    data->available_credits = 100; // Example
+    data->kwh_consumed = 50; // Example
+    return 0; // Success
+}
+#endif
+
+/* Private method implementations */
+static int energy_meter_write(meter_t* self, char* command, uint8_t len) {
+
+    energy_meter_encode_data((uint8_t*) command, len);
+
+    int ret = self->meter_interface.tx(&self->meter_interface, command, len);
+
+    if(ret != len){
+        return METER_OP_ERROR;
+    }
+    
+    return ret;
+}
+
+static int energy_meter_read(meter_t* self, char* buffer, uint8_t len) {
+
+    int ret = self->meter_interface.rx(&self->meter_interface, (uint8_t*)buffer, len);
+    
+    if(ret < 0){
+        return METER_OP_ERROR;
+    }
+
+    energy_meter_decode_data((uint8_t*)buffer, ret);
+
+    return ret; 
+}
+
+static int energy_meter_read_meter_address(meter_t* self, uint16_t address, char* rx_buffer, uint8_t size) {
+   
+    CommandResult cmd  = BuildReadCommand(address, 1);
+
+	if(cmd.length <= 0){
+		LOG(LVL_ERROR, "Error getting meter read command\n");
+		return METER_OP_ERROR;
+	}
+
+	/** Clear receive buffer */
+	memset(rx_buffer, 0, size);
+
+	meter_data_req_t req = {
+		.command 		= (char*) cmd.command,
+		.command_len 	= (uint8_t) cmd.length,
+		.buffer 		= rx_buffer,
+		.buffer_size 	= size
+	};
+
+	int ret = energy_meter_fetch_sensor_data(self,req);
+
+	if(ret <= 0){
+		return METER_OP_ERROR;
+	}
+
+    return METER_OP_OK; // Success
+}
+
+static void energy_meter_encode_data(uint8_t* buffer, int len){
+
+    for (int i = 0; i < len; i++) {
+      buffer[i] = energy_meter_calculate_parity(buffer[i]);
+    }
+
+}
+
+static void energy_meter_decode_data(uint8_t* buffer, int len){
+
+    for(int i = 0; i < len; i++){
+        buffer[i] = buffer[i] & 0x7F;
+    }
+
+}
+
+static uint8_t energy_meter_calculate_parity(uint8_t data) {
+    // Calculate parity for the given data byte
+    int count = 0;
+    for (int i = 0; i < 7; i++) {
+        if (data & (1 << i)) {
+            count++;
+        }
+    }
+    // Calculate parity (even parity)
+    int parity_bit = count % 2 == 0 ? 0 : 1;
+
+    // Set the 8th bit (parity bit) in the data byte
+    return (data & 0x7F) | (parity_bit << 7);
+}
+
+static int energy_meter_write_meter_address(meter_t* self, uint16_t address, char* data, char* rx_buffer, uint8_t size) {
+    
+    CommandResult cmd= BuildWriteCommand(address, data);
+
+	if(cmd.length <= 0){
+		LOG(LVL_ERROR, "Error getting command to write at address %04X \n", address);
+		return -1;
+	}
+
+	memset(rx_buffer, 0, size);
+
+	meter_data_req_t req = {
+		.command 		= (char*) cmd.command,
+		.command_len 	= (uint8_t) cmd.length,
+		.buffer 		= rx_buffer,
+		.buffer_size 	= size
+	};
+
+	int ret = energy_meter_fetch_sensor_data(self, req);
+
+	if(ret <= 0){
+		return METER_OP_ERROR;
+	}
+
+	return ret;
+}
+
+static void remove_spaces(char* str) {
+    int i = 0, j = 0;
+    while (str[i]) {
+        if (str[i] != ' ') {
+            str[j++] = str[i];
+        }
+        i++;
+    }
+    str[j] = '\0';  // Null-terminate the resulting string
+}
+
+static int energy_meter_write_token(meter_t* self, char* token) {
+    
+    /* Remove spaces from the token */
+    remove_spaces(token);
+
+	char rx_response[ENERGY_METER_RX_BUFFER_SIZE];
+
+	int ret = energy_meter_write_meter_address(self, METER_TOKEN_ADDRESS, token, rx_response, sizeof(rx_response));
+
+	if (ret <= 0){
+		return METER_RESPONSE_NAN;
+	}
+
+	if(rx_response[ret-1] == METER_RESPONSE_ACK ){
+		return METER_RESPONSE_ACK;
+	}
+	else if(rx_response[ret-1] == METER_RESPONSE_NAK){
+		return METER_RESPONSE_NAK;
+	}
+
+	return METER_RESPONSE_NAN;
+}
+
+/* Function to get the instance of the meter */
+void meter_create(meter_t *self){
+
+    self->init = energy_meter_init;
+    self->configure = energy_meter_configure;
+    self->update_realtime_data = energy_meter_update_realtime_data;
+    self->token_injection_tx = energy_meter_token_injection_tx,
+    self->fetch_sensor_data = energy_meter_fetch_sensor_data;
+
+}

--- a/source/example_apps/evaluation_app/drivers/meter/enlight/enlight.h
+++ b/source/example_apps/evaluation_app/drivers/meter/enlight/enlight.h
@@ -1,0 +1,137 @@
+#ifndef _ENLIGHT_METER_H
+#define _ENLIGHT_METER_H
+
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <usart2.h>
+#include <meter_data.h>
+
+#define ENERGY_METER_RX_BUFFER_SIZE 100
+
+/**
+ * @brief Struct used to by the data fetcher to obtain data.
+ * 
+ */
+typedef struct meter_data_req {
+    char* command;      /** Command to send to the meter */
+    uint8_t command_len; /* Length of the command */
+    char* buffer;       /* Buffer to store the response data */
+    uint8_t buffer_size; /* Size of the buffer */
+} meter_data_req_t;
+
+/**
+ * @brief Response from the meter after an operation
+ * 
+ */
+typedef enum meter_response {
+    METER_RESPONSE_ACK = 0x06,
+    METER_RESPONSE_NAK = 0x15,
+    METER_RESPONSE_NAN = 0xFF
+} meter_response_t;
+
+typedef enum {
+    METER_OP_ERROR,
+    METER_OP_CONFIG_ERROR,
+    METER_OP_OK
+}meter_op_t;
+
+
+#ifdef SIMULATE_METER_DATA
+/**
+ * @brief Struct to store simulated realtime data from the meter
+ * 
+ */
+typedef struct simulated_realtime_data {
+    int available_credits;
+    int kwh_consumed;
+} simulated_realtime_data_t;
+#endif 
+
+/**
+ * @brief Current context of a token injection
+ * 
+ */
+typedef struct {
+    uint32_t timestamp;
+    uint64_t serial;
+    char token[50];
+    int tx_status;
+    float units_before_injection;
+    float units_after_injection;
+    float injected_tokens;
+} token_injection_ctx;
+
+/**
+ * @brief Token injection operation status
+ * 
+ */
+typedef enum {
+    METER_TOKEN_INJECTION_SUCCESS = 0x01,
+    METER_TOKEN_INJECTION_FAIL = 0x00
+}token_injection_status_e;
+
+
+/**
+ * @brief meter class representation
+ * 
+ */
+typedef struct meter {
+
+    /* meter data */
+    meter_data_t m_data;
+
+    /* Meter comminication interface */
+    uart_t meter_interface;
+
+    /* Methods */
+    /**
+     * @brief Initialize the meter
+     * @param self meter object
+     * @return int operation status
+     */
+    int (*init)(struct meter* self);
+
+    /**
+     * @brief Configure the meter by reading the configuration data from the meter
+     * @param self meter object
+     * @return int operation status
+     * 
+     */
+    int (*configure)(struct meter* self);
+
+    /**
+     * @brief get realtime data from the meter and update the data object
+     * @param self meter object
+     * @return int operation status
+     * 
+     */
+    int (*update_realtime_data)(struct meter* self);
+
+    /**
+     * @brief Transaction to inject tokens into the meter
+     * @param self meter_object
+     * @param ctx current context information
+     * @return int operation status
+     * 
+     */
+    int (*token_injection_tx)(struct meter* self, token_injection_ctx* ctx);
+
+    /**
+     * @brief fetch data from the sensor. takes in a request and populates th requests response
+     * @param self meter object
+     * @param req meter data request object (meter_data_req_t)
+     * @return int operation status
+     */
+    int (*fetch_sensor_data)(struct meter* self, meter_data_req_t req);
+
+} meter_t;
+
+
+/* Create a meter */
+void meter_create(meter_t *self);
+
+
+
+#endif //_ENLIGHT_METER_H

--- a/source/example_apps/evaluation_app/drivers/time/delay_timer/delay_timer.c
+++ b/source/example_apps/evaluation_app/drivers/time/delay_timer/delay_timer.c
@@ -1,0 +1,27 @@
+#include <delay_timer.h>
+
+static void delay_timer_reset(delay_timer_t* self){
+    self->ms_counter = 0;
+}
+
+static uint64_t delay_timer_get(delay_timer_t* self){
+    return self->ms_counter;
+}
+
+static void delay_timer_tick(delay_timer_t* self){
+    self->ms_counter += 50;
+}
+
+ 
+
+delay_timer_t* get_delay_timer_instance(){
+
+   static delay_timer_t _delay_timer = {
+    .get = delay_timer_get,
+    .reset = delay_timer_reset,
+    .tick = delay_timer_tick,
+   };
+
+    return &_delay_timer;
+}
+

--- a/source/example_apps/evaluation_app/drivers/time/delay_timer/delay_timer.h
+++ b/source/example_apps/evaluation_app/drivers/time/delay_timer/delay_timer.h
@@ -1,0 +1,23 @@
+#ifndef _DELAY_TIMER_H
+#define _DELAY_TIMER_H
+
+#include <stdint.h>
+
+typedef struct delay_timer_t delay_timer_t;
+
+struct delay_timer_t{ 
+
+    volatile uint64_t ms_counter;
+
+    void (*reset)(struct delay_timer_t*);
+
+    uint64_t (*get)(struct delay_timer_t*);
+
+    void (*tick)(struct delay_timer_t*);
+
+};
+
+
+delay_timer_t* get_delay_timer_instance();
+
+#endif //_DELAY_TIMER_H

--- a/source/example_apps/evaluation_app/fsm/fsm.c
+++ b/source/example_apps/evaluation_app/fsm/fsm.c
@@ -1,0 +1,30 @@
+#include <fsm.h>
+
+#define DEBUG_LOG_MODULE_NAME "FSM"
+#define DEBUG_LOG_MAX_LEVEL LVL_INFO
+#include "debug_log.h"
+
+void init_state_machine(StateMachine *sm, int initial_state, StateHandlerFunc* handlers) {
+    sm->current_state = initial_state;
+    sm->is_running = true;
+    sm->state_handlers = handlers;  // Assign state handlers array
+}
+
+void run_state_machine(StateMachine *sm) {
+    if (sm->is_running) {
+        sm->current_state = base_state_transition(sm); // Perform state transition
+        if (sm->current_state == -1) {
+            sm->is_running = false; // Stop if in a terminal state
+        }
+    }
+}
+
+int base_state_transition(StateMachine *sm) {
+    // Call the state handler for the current state
+    int ret = sm->state_handlers[sm->current_state](sm);
+
+    LOG(LVL_ERROR, "Transitioning from state: %d >> %d\n", sm->current_state, ret);
+
+
+    return ret; // Call the current state handler
+}

--- a/source/example_apps/evaluation_app/fsm/fsm.h
+++ b/source/example_apps/evaluation_app/fsm/fsm.h
@@ -1,0 +1,35 @@
+#ifndef _FSM_H
+#define _FSM_H
+
+#include <stdio.h>
+#include <stdbool.h>
+
+typedef struct StateMachine StateMachine;
+typedef int (*StateHandlerFunc)(struct StateMachine *);
+
+// Base StateMachine "class"
+struct StateMachine {
+
+    int current_state;             // Current state of the machine
+    bool is_running;               // Flag to indicate if the machine is running
+
+    // State transition function pointer
+    int (*state_transition)(struct StateMachine *);
+
+    // Pointer to an array of function pointers for state handlers
+    StateHandlerFunc* state_handlers;
+
+};
+
+
+// Initialize the base state machine
+void init_state_machine(StateMachine *sm, int initial_state, StateHandlerFunc* handlers);
+
+// Run the base state machine (ticks through states)
+void run_state_machine(StateMachine *sm);
+
+// Base state transition function
+int base_state_transition(StateMachine *sm);
+
+
+#endif //_FSM_H

--- a/source/example_apps/evaluation_app/queues/queue.c
+++ b/source/example_apps/evaluation_app/queues/queue.c
@@ -1,0 +1,31 @@
+#include "queue.h"
+#include <string.h>  // for memcpy
+
+// Initialize the generic queue
+void queue_init(generic_queue_t *queue, void *buffer_storage, size_t element_size, size_t max_size) {
+    queue->buffer_storage = buffer_storage;
+    queue->element_size = element_size;
+    queue->max_size = max_size;
+    // Initialize the internal circular buffer
+    circular_buffer_init(&queue->circular_buffer, buffer_storage, element_size, max_size);
+}
+
+// Push data into the queue
+bool queue_push(generic_queue_t *queue, const void *data) {
+    return circular_buffer_push(&queue->circular_buffer, data);
+}
+
+// Pop data from the queue
+bool queue_pop(generic_queue_t *queue, void *data) {
+    return circular_buffer_pop(&queue->circular_buffer, data);
+}
+
+// Check if the queue is full
+bool queue_is_full(generic_queue_t *queue) {
+    return circular_buffer_is_full(&queue->circular_buffer);
+}
+
+// Check if the queue is empty
+bool queue_is_empty(generic_queue_t *queue) {
+    return circular_buffer_is_empty(&queue->circular_buffer);
+}

--- a/source/example_apps/evaluation_app/queues/queue.h
+++ b/source/example_apps/evaluation_app/queues/queue.h
@@ -1,0 +1,32 @@
+#ifndef _QUEUE_H
+#define _QUEUE_H
+
+#include <stdbool.h>
+#include <stddef.h> // for size_t
+
+#include <circular_buffer.h>
+
+// Queue structure based on circular buffer
+typedef struct {
+    circular_buffer_t circular_buffer;  // Circular buffer for internal storage
+    void *buffer_storage;               // Generic pointer to the actual queue data storage
+    size_t element_size;                // Size of each element in the queue
+    size_t max_size;                    // Maximum number of elements in the queue
+} generic_queue_t;
+
+// Initialize the generic queue
+void queue_init(generic_queue_t *queue, void *buffer_storage, size_t element_size, size_t max_size);
+
+// Push data into the queue
+bool queue_push(generic_queue_t *queue, const void *data);
+
+// Pop data from the queue
+bool queue_pop(generic_queue_t *queue, void *data);
+
+// Check if the queue is full
+bool queue_is_full(generic_queue_t *queue);
+
+// Check if the queue is empty
+bool queue_is_empty(generic_queue_t *queue);
+
+#endif // _QUEUE_H

--- a/source/example_apps/evaluation_app/queues/token_injection_response_queue/token_injection_response_queue.c
+++ b/source/example_apps/evaluation_app/queues/token_injection_response_queue/token_injection_response_queue.c
@@ -1,0 +1,1 @@
+#include <token_injection_response_queue.h>

--- a/source/example_apps/evaluation_app/queues/token_injection_response_queue/token_injection_response_queue.h
+++ b/source/example_apps/evaluation_app/queues/token_injection_response_queue/token_injection_response_queue.h
@@ -1,0 +1,11 @@
+#ifndef _TOKEN_INJECTION_RESPONSE_QUEUE_H
+#define _TOKEN_INJECTION_RESPONSE_QUEUE_H
+
+#include <token_injection_response.h>
+#include<queue.h>
+
+#define TOKEN_INJECTION_REPONSE_QUEUE_SIZE 5
+
+extern generic_queue_t token_injection_response_queue;
+
+#endif //_TOKEN_INJECTION_RESPONSE_QUEUE_H

--- a/source/example_apps/evaluation_app/queues/token_recv_queue/token_recv_queue.h
+++ b/source/example_apps/evaluation_app/queues/token_recv_queue/token_recv_queue.h
@@ -1,0 +1,15 @@
+#ifndef _TOKEN_RECV_QUEUE_H
+#define _TOKEN_RECV_QUEUE_H
+
+#include <queue.h>
+
+#define TOKEN_RCV_QUEUE_SIZE 5
+
+typedef struct {
+    uint64_t serial;
+    char token[20];
+}token_t;
+
+extern generic_queue_t token_rcv_queue;
+
+#endif //_TOKEN_RECV_QUEUE_H

--- a/source/example_apps/evaluation_app/services/controllers/meter_controller/meter_controller.c
+++ b/source/example_apps/evaluation_app/services/controllers/meter_controller/meter_controller.c
@@ -1,0 +1,114 @@
+#include "meter_controller.h"
+#include <token_injection_response_queue.h>
+#include <token_recv_queue.h>
+
+#define DEBUG_LOG_MODULE_NAME "METER_FSM"
+#define DEBUG_LOG_MAX_LEVEL LVL_INFO
+#include "debug_log.h"
+
+// generic_queue_t token_injection_response_queue;
+// generic_queue_t token_rcv_queue;
+
+// Meter state handlers array
+StateHandlerFunc meter_state_handlers[METER_STATE_MAX] = {
+    meter_idle_state,
+    meter_config_state,
+    meter_active_state,
+    meter_error_state
+};
+
+// Initialize the meter state machine
+void init_meter_state_machine(MeterStateMachine *msm, int initial_state) {
+    msm->current_state = initial_state;
+    msm->is_running = true;
+    msm->state_handlers = meter_state_handlers; // Assign meter-specific state handlers
+
+    // Create an enlight meter object
+    meter_create(&msm->enlight_meter);
+}
+
+// Run the meter state machine
+void run_meter_state_machine(MeterStateMachine *msm) {
+    if (msm->is_running) {
+        int next_state = msm->state_handlers[msm->current_state](msm); // Call current state handler
+        LOG(LVL_DEBUG, "Transitioning from state: %d >> %d\n", msm->current_state, next_state);
+        if (next_state == -1) {
+            msm->is_running = false; // Stop if in a terminal state
+        } else {
+            msm->current_state = next_state;
+        }
+    }
+}
+
+// Meter state handler functions
+int meter_idle_state(MeterStateMachine *msm) {
+
+    for(volatile int i = 0; i < 2000000; i++){}
+    
+    int ret = msm->enlight_meter.init(&msm->enlight_meter);
+    if (ret == METER_OP_OK) {
+        return METER_STATE_CONFIG;
+    }
+    return METER_STATE_IDLE; 
+}
+
+int meter_config_state(MeterStateMachine *msm) {
+    int ret = msm->enlight_meter.configure(&msm->enlight_meter);
+    if (ret != METER_OP_OK) {
+        return METER_STATE_ERROR;
+    }
+    return METER_STATE_ACTIVE; 
+}
+
+int meter_active_state(MeterStateMachine *msm) {
+    int ret = msm->enlight_meter.update_realtime_data(&msm->enlight_meter);
+    if (ret != METER_OP_OK) {
+        return METER_STATE_ERROR;
+    }
+
+    if((!queue_is_empty(&token_rcv_queue))){
+        token_t rcv_token = {
+            .serial = 0,
+        };
+
+        queue_pop(&token_rcv_queue, &rcv_token);
+
+        if(rcv_token.serial != 0){
+
+            token_injection_ctx ctx;
+            ctx.serial = rcv_token.serial;
+            strncpy(ctx.token, rcv_token.token, 20);
+
+            int ret = msm->enlight_meter.token_injection_tx(&msm->enlight_meter, &ctx);
+
+            if(ret != METER_OP_OK){
+                LOG(LVL_ERROR, "Error Injecting Token\n");
+            }
+
+            token_injection_response_t injection_resp = {
+                .start_x = 0x70ffee,
+                .serial = ctx.serial,
+                .injected_units = ctx.injected_tokens,
+                .is_valid = ret,
+                .end_x = 0x90ffee,
+            };
+
+            if(!queue_is_full(&token_injection_response_queue)){
+                queue_push(&token_injection_response_queue, &injection_resp);
+            }
+
+            if(ret != METER_OP_OK){
+                return METER_STATE_ERROR;
+            }
+
+        }
+
+    }
+
+    return METER_STATE_ACTIVE; 
+}
+
+int meter_error_state(MeterStateMachine *msm) {
+    LOG(LVL_ERROR, "Error communicating with Meter\n");
+    return METER_STATE_CONFIG; 
+}

--- a/source/example_apps/evaluation_app/services/controllers/meter_controller/meter_controller.h
+++ b/source/example_apps/evaluation_app/services/controllers/meter_controller/meter_controller.h
@@ -1,0 +1,42 @@
+#ifndef _METER_STATE_MACHINE_H
+#define _METER_STATE_MACHINE_H
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <enlight.h>
+
+// Meter-specific states
+typedef enum {
+    METER_STATE_IDLE,
+    METER_STATE_CONFIG,
+    METER_STATE_ACTIVE,
+    METER_STATE_ERROR,
+    METER_STATE_MAX // Sentinel value for state count
+} MeterState;
+
+typedef struct MeterStateMachine MeterStateMachine;
+
+// Function pointer type for state handler functions
+typedef int (*StateHandlerFunc)(struct MeterStateMachine *);
+
+// MeterStateMachine structure containing all necessary elements
+struct MeterStateMachine {
+    int current_state;             // Current state of the machine
+    bool is_running;               // Flag to indicate if the machine is running
+
+    StateHandlerFunc* state_handlers; // Pointer to an array of state handler functions
+
+    meter_t enlight_meter;          // Embedded meter object
+};
+
+// Meter state handler functions
+int meter_idle_state(MeterStateMachine *msm);
+int meter_config_state(MeterStateMachine *msm);
+int meter_active_state(MeterStateMachine *msm);
+int meter_error_state(MeterStateMachine *msm);
+
+// Initialize and run the meter state machine
+void init_meter_state_machine(MeterStateMachine *msm, int initial_state);
+void run_meter_state_machine(MeterStateMachine *msm);
+
+#endif // _METER_STATE_MACHINE_H

--- a/source/example_apps/evaluation_app/utils/circular_buffer/circular_buffer.c
+++ b/source/example_apps/evaluation_app/utils/circular_buffer/circular_buffer.c
@@ -1,0 +1,59 @@
+#include <circular_buffer.h>
+#include <string.h>  // for memcpy
+
+// Initialize the circular buffer
+void circular_buffer_init(circular_buffer_t *cb, void *buffer, size_t element_size, size_t max_elements) {
+    cb->buffer = buffer;
+    cb->element_size = element_size;
+    cb->max_elements = max_elements;
+    cb->head = 0;
+    cb->tail = 0;
+    cb->is_full = false;
+}
+
+// Push an element into the buffer
+bool circular_buffer_push(circular_buffer_t *cb, const void *item) {
+    if (circular_buffer_is_full(cb)) {
+        return false; // Buffer is full
+    }
+
+    // Copy item to the tail of the buffer
+    memcpy((uint8_t *)cb->buffer + (cb->tail * cb->element_size), item, cb->element_size);
+
+    // Move the tail to the next position
+    cb->tail = (cb->tail + 1) % cb->max_elements;
+
+    // If tail catches up to head, the buffer is now full
+    if (cb->tail == cb->head) {
+        cb->is_full = true;
+    }
+
+    return true;
+}
+
+// Pop an element from the buffer
+bool circular_buffer_pop(circular_buffer_t *cb, void *item) {
+    if (circular_buffer_is_empty(cb)) {
+        return false; // Buffer is empty
+    }
+
+    // Copy the item from the head of the buffer
+    memcpy(item, (uint8_t *)cb->buffer + (cb->head * cb->element_size), cb->element_size);
+
+    // Move the head to the next position
+    cb->head = (cb->head + 1) % cb->max_elements;
+
+    cb->is_full = false; // Popping an element makes the buffer not full
+
+    return true;
+}
+
+// Check if the buffer is full
+bool circular_buffer_is_full(circular_buffer_t *cb) {
+    return cb->is_full;
+}
+
+// Check if the buffer is empty
+bool circular_buffer_is_empty(circular_buffer_t *cb) {
+    return (cb->head == cb->tail && !cb->is_full);
+}

--- a/source/example_apps/evaluation_app/utils/circular_buffer/circular_buffer.h
+++ b/source/example_apps/evaluation_app/utils/circular_buffer/circular_buffer.h
@@ -1,0 +1,33 @@
+#ifndef _CIRCULAR_BUFFER_H
+#define _CIRCULAR_BUFFER_H
+
+#include <stdbool.h>
+#include <stddef.h> // for size_t
+#include <stdint.h>
+
+// Circular buffer structure
+typedef struct {
+    void *buffer;     // Buffer memory to hold data
+    size_t element_size;  // Size of each element in the buffer
+    size_t max_elements;  // Maximum number of elements the buffer can hold
+    size_t head;      // Index of the head (next item to pop)
+    size_t tail;      // Index of the tail (next empty spot to push)
+    bool is_full;     // Flag to indicate if the buffer is full
+} circular_buffer_t;
+
+// Initialize the circular buffer
+void circular_buffer_init(circular_buffer_t *cb, void *buffer, size_t element_size, size_t max_elements);
+
+// Push an element into the buffer
+bool circular_buffer_push(circular_buffer_t *cb, const void *item);
+
+// Pop an element from the buffer
+bool circular_buffer_pop(circular_buffer_t *cb, void *item);
+
+// Check if the buffer is full
+bool circular_buffer_is_full(circular_buffer_t *cb);
+
+// Check if the buffer is empty
+bool circular_buffer_is_empty(circular_buffer_t *cb);
+
+#endif // _CIRCULAR_BUFFER_H

--- a/source/example_apps/evaluation_app/utils/command_builder/command_builder.c
+++ b/source/example_apps/evaluation_app/utils/command_builder/command_builder.c
@@ -1,0 +1,87 @@
+#include "command_builder.h"
+
+uint8_t CalcBCC(const char* data, int startPos, int len) {
+    uint8_t bcc = (uint8_t)data[startPos];
+    for (int i = 1; i < len; i++) {
+        bcc ^= (uint8_t)data[startPos + i];
+    }
+    return bcc;
+}
+
+
+CommandResult BuildReadCommand(uint16_t regID, int len) {
+    CommandResult result;
+    result.command[0] = '\0'; // Initialize command array
+    result.length = 0;
+
+    if (len > 0xf) {
+        len = 0;
+    }
+
+    char regIDHex[5]; // 4 digits + null terminator
+    if (snprintf(regIDHex, sizeof(regIDHex), "%04X", regID) >= (int) sizeof(regIDHex)) {
+        // Handle error if regIDHex is truncated
+        // Return an empty result or some error indicator
+        return result;
+    }
+
+    char lenHex[2]; // 1 digit + null terminator
+    if (snprintf(lenHex, sizeof(lenHex), "%X", len) >= (int) sizeof(lenHex)) {
+        // Handle error if lenHex is truncated
+        return result;
+    }
+
+    char cmnd[MAX_METER_COMMAND_SIZE]; // Adjust size as needed
+    int written = snprintf(cmnd, sizeof(cmnd), "R%c%s%s%c", S_STX, regIDHex, lenHex, S_ETX);
+
+    if (written < 0 || written >= (int) sizeof(cmnd)) {
+        // Handle error if cmnd was truncated
+        return result;
+    }
+
+    int chksLen = strlen(cmnd);
+    uint8_t chkSum = CalcBCC(cmnd, 0, chksLen);
+
+    written = snprintf(result.command, sizeof(result.command), "%c%s%c", S_SOH, cmnd, chkSum);
+
+    if (written < 0 || written >= (int) sizeof(result.command)) {
+        // Handle error if result.command was truncated
+        return result;
+    }
+
+    result.length = strlen(result.command);
+    return result;
+}
+
+CommandResult BuildWriteCommand(uint16_t regID, char* wrData) {
+    CommandResult result;
+    result.command[0] = '\0'; // Initialize command array
+    result.length = 0;
+
+    char regIDHex[5]; // 4 digits + null terminator
+    if (snprintf(regIDHex, sizeof(regIDHex), "%04X", regID) >= (int) sizeof(regIDHex)) {
+        // Handle error if regIDHex is truncated
+        return result;
+    }
+
+    char cmnd[MAX_METER_COMMAND_SIZE]; // Adjust size as needed
+    int written = snprintf(cmnd, sizeof(cmnd), "W%c%s(%s)%c", S_STX, regIDHex, wrData, S_ETX);
+
+    if (written < 0 || written >= (int) sizeof(cmnd)) {
+        // Handle error if cmnd was truncated
+        return result;
+    }
+
+    int chksLen = strlen(cmnd);
+    uint8_t chkSum = CalcBCC(cmnd, 0, chksLen);
+
+    written = snprintf(result.command, sizeof(result.command), "%c%s%c", S_SOH, cmnd, chkSum);
+
+    if (written < 0 || written >= (int) sizeof(result.command)) {
+        // Handle error if result.command was truncated
+        return result;
+    }
+
+    result.length = strlen(result.command);
+    return result;
+}

--- a/source/example_apps/evaluation_app/utils/command_builder/command_builder.h
+++ b/source/example_apps/evaluation_app/utils/command_builder/command_builder.h
@@ -1,0 +1,51 @@
+#ifndef _METER_COMMAND_BUILDER_H
+#define _METER_COMMAND_BUILDER_H
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#define S_STX 0x02
+#define S_ETX 0x03
+#define S_SOH 0x01
+
+#define MAX_METER_COMMAND_SIZE 256
+
+typedef struct {
+    char command[MAX_METER_COMMAND_SIZE]; // Adjust size as needed
+    size_t length;
+}CommandResult;
+
+/**
+ * @brief Calculates the Block Check Character (BCC) by XORing the bytes of the given string from startPos to startPos + len.
+ * 
+ * @param data buffer containing the data
+ * @param startPos starting position of the data (mostly begining of the buffer)
+ * @param len  length of the buffer
+ * @return uint8_t Bcc value
+ */
+uint8_t CalcBCC(const char* data, int startPos, int len);
+
+/**
+ * @brief Build a command used the read the specified register from the meter
+ * 
+ * @param regID Register to read (HEX)
+ * @param len number of registers to read 
+ * @return CommandResult packaged command for sending
+ */
+CommandResult BuildReadCommand(uint16_t regID, int len);
+
+/**
+ * @brief Build a command to enable writing to the meter
+ * 
+ * @param regID Register to write to 
+ * @param wrData Data to write to the meter
+ * @return CommandResult  packaged command for sending
+ */
+CommandResult BuildWriteCommand(uint16_t regID, char* wrData) ;
+
+
+
+#endif //_METER_COMMAND_BUILDER_H

--- a/source/example_apps/evaluation_app/utils/meter_hex_to_int/meter_hex_to_int.c
+++ b/source/example_apps/evaluation_app/utils/meter_hex_to_int/meter_hex_to_int.c
@@ -1,0 +1,33 @@
+#include <meter_hex_to_int.h>
+
+unsigned long long extract_hex_value(const char *str) {
+    // Find the opening and closing brackets
+    const char *start = strchr(str, '(');
+    const char *end = strchr(str, ')');
+
+    if (!start || !end || start >= end) {
+        // If we don't find the brackets or they are in the wrong order
+        return -1; // Error indicator
+    }
+
+    // Move the start pointer to the first character after '('
+    start++;
+
+    // Calculate the length of the hex substring
+    size_t hex_len = end - start;
+
+    // Create a buffer to hold the hex string and add a null terminator
+    char hex_value[hex_len + 1];
+    strncpy(hex_value, start, hex_len);
+    hex_value[hex_len] = '\0';
+
+    // Convert the hex string to an unsigned long long integer
+    unsigned long long result = strtoull(hex_value, NULL, 16);
+
+    return result;
+}
+
+unsigned long long hex_string_to_int(const char* str){
+
+    return strtoull(str, NULL, 16);   
+}

--- a/source/example_apps/evaluation_app/utils/meter_hex_to_int/meter_hex_to_int.h
+++ b/source/example_apps/evaluation_app/utils/meter_hex_to_int/meter_hex_to_int.h
@@ -1,0 +1,13 @@
+#ifndef _METER_HEX_TO_INT_H
+#define _METER_HEX_TO_INT_H
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+unsigned long long extract_hex_value(const char *str);
+
+unsigned long long hex_string_to_int(const char* str);
+
+#endif //_METER_HEX_TO_INT_H


### PR DESCRIPTION
Adds an abstructed UART driver implementation that enables effiecient communication with Energy Meters.

This was neccessary as the one provided by the SDK is not scalable and depends on two other timers.